### PR TITLE
fix: room ID for tokenSent event to reflect chainId

### DIFF
--- a/hooks/useDetectDepositConfirmation.ts
+++ b/hooks/useDetectDepositConfirmation.ts
@@ -70,11 +70,11 @@ export const useDetectDepositConfirmation = () => {
 
     if (sentNative)
       roomId = buildTokenSentRoomId(
-        srcChain.chainName.toLowerCase(),
+        srcChain,
         asset.chain_aliases[destChain.chainName.toLowerCase()]
           .fullDenomPath as string,
         destAddress.toLowerCase(),
-        destChain.chainName.toLowerCase(),
+        destChain,
         depositAddress
       );
     else

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,3 +1,4 @@
+import { ChainInfo } from "@axelar-network/axelarjs-sdk";
 import toast from "react-hot-toast";
 import { ENVIRONMENT } from "../config/constants";
 import { Environment } from "./enums";
@@ -9,18 +10,19 @@ export function copyToClipboard(value: string) {
 }
 
 export function buildTokenSentRoomId(
-  sourceChain: string,
+  srcChainInfo: ChainInfo,
   denom: string,
   destinationAddress: string,
-  destinationChain: string,
+  destChainInfo: ChainInfo,
   sender: string
 ): string {
+
   const topic = {
     type: 'token-sent',
-    sourceChain,
+    sourceChain: srcChainInfo.chainIdentifier[ENVIRONMENT],
     denom,
     destinationAddress,
-    destinationChain,
+    destinationChain: destChainInfo.chainIdentifier[ENVIRONMENT],
     sender,
   };
 


### PR DESCRIPTION
Issue: Transfers for native deposits were not showing as complete for transfers to/from Goerli, depsite tranfers at the network going thorugh.

Fix: the topic ID for the tokenSent event used the chain name instead of chain Id. 