### PR TITLE
fix: native eth deposits send from mm not working

### DIFF
--- a/components/swap/states/parts/EvmWalletTransfer.tsx
+++ b/components/swap/states/parts/EvmWalletTransfer.tsx
@@ -225,7 +225,7 @@ export const EvmWalletTransfer = () => {
     if (ENVIRONMENT === "testnet") {
       // WRAP
       if (
-        asset?.native_chain === srcChain.chainIdentifier[ENVIRONMENT] &&
+        asset?.native_chain === srcChain.chainName.toLowerCase() &&
         asset.is_native_asset
       ) {
         return sendTransactionAsync?.()


### PR DESCRIPTION
it looks like this asset config will always have chain name lowercased as its "native_chain", 

so this line was never evaluating to true: https://github.com/axelarnetwork/axelar-satellite/blob/develop/components/swap/states/parts/EvmWalletTransfer.tsx#L228

and the fix is to reference chain name instead