### PR TITLE
feat: max button takes native asset tx fee into account

### DIFF
--- a/components/swap/parts/TokenSelector.tsx
+++ b/components/swap/parts/TokenSelector.tsx
@@ -26,6 +26,7 @@ import { useIsTerraConnected } from "../../../hooks/terra/useIsTerraConnected";
 import { useConnectTerraStation } from "../../../hooks/terra/useConnectTerraStation";
 import { NativeAssetConfig } from "../../../config/web3/evm/native-assets";
 import { UnwrapToNativeChainCheckbox } from "./UnwrapToNativeChainCheckbox";
+import { MaxButton } from "../../../features/max-button";
 
 const defaultChainImg = "/assets/chains/default.logo.svg";
 
@@ -535,14 +536,7 @@ export const TokenSelector = () => {
             className="checkbox checkbox-sm checkbox-primary"
           /> */}
           {addTokenToMetamaskButton()}
-          {swapOrigin === SwapOrigin.APP && (
-            <button
-              className="btn btn-info btn-xs"
-              onClick={handleOnMaxButtonClick}
-            >
-              Max
-            </button>
-          )}
+          <MaxButton />
         </div>
       </div>
       <div className="flex justify-between mt-2">

--- a/features/max-button/MaxButton.tsx
+++ b/features/max-button/MaxButton.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import { useSwapStore } from "../../store";
+import { useGetAllowedMaxBalance } from "./hooks/useGetAllowedMaxBalance";
+
+export const MaxButton = () => {
+  const setTokensToTransfer = useSwapStore(
+    (state) => state.setTokensToTransfer
+  );
+  const maxBalance = useGetAllowedMaxBalance();
+
+  function handleOnMaxButtonClick() {
+    setTokensToTransfer(maxBalance);
+  }
+
+  return (
+    <button className="btn btn-info btn-xs" onClick={handleOnMaxButtonClick}>
+      Max
+    </button>
+  );
+};

--- a/features/max-button/hooks/index.ts
+++ b/features/max-button/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from "./useGetAllowedMaxBalance";

--- a/features/max-button/hooks/useGetAllowedMaxBalance.ts
+++ b/features/max-button/hooks/useGetAllowedMaxBalance.ts
@@ -1,0 +1,91 @@
+import { ethers } from "ethers";
+import { useCallback, useEffect, useState } from "react";
+import {
+  erc20ABI,
+  useAccount,
+  useBalance,
+  useContractRead,
+  useProvider,
+} from "wagmi";
+import {
+  getSrcChainId,
+  getSrcTokenAddress,
+  useSwapStore,
+} from "../../../store";
+import { Hash } from "../../../types";
+
+const { utils } = ethers;
+const { formatUnits } = utils;
+
+/**
+ * Returns the max balance that a user can select by
+ * taking into account the transfer fee.
+ */
+export function useGetAllowedMaxBalance() {
+  const srcChainId = useSwapStore(getSrcChainId);
+  const srcTokenAddress = useSwapStore(getSrcTokenAddress);
+  const depositAddress = useSwapStore((state) => state.depositAddress);
+  const asset = useSwapStore((state) => state.asset);
+
+  const { address } = useAccount();
+  const { data: balance } = useBalance({
+    chainId: srcChainId,
+    address,
+  });
+  const provider = useProvider({
+    chainId: srcChainId,
+  });
+
+  const { data: tokenBalance } = useContractRead({
+    enabled: !asset?.is_native_asset,
+    address: srcTokenAddress as string,
+    abi: erc20ABI,
+    chainId: srcChainId,
+    functionName: "balanceOf",
+    args: [address as Hash],
+  });
+
+  const [maxBalance, setMaxBalance] = useState<string>("0");
+
+  const estimateGas = useCallback(async () => {
+    return provider
+      .estimateGas({
+        to: depositAddress,
+        value: utils.parseEther("1.0"),
+      })
+      .then((bigNum) => bigNum.mul(5));
+  }, [provider, depositAddress]);
+
+  const computeRealMaxBalance = useCallback(
+    async (balance: ethers.BigNumber) => {
+      // if erc20 return token balance
+      if (!asset?.is_native_asset)
+        return formatUnits(tokenBalance || "0", asset?.decimals || 18);
+
+      // if native asset return native token balance minus tx fee
+      const gas = await estimateGas();
+      const gasPrice = await provider.getGasPrice();
+      const fee = gas.mul(gasPrice);
+      return formatUnits(balance.sub(fee), asset?.decimals || 18).substring(
+        0,
+        10
+      );
+    },
+    [
+      provider,
+      asset?.decimals,
+      asset?.is_native_asset,
+      tokenBalance,
+      estimateGas,
+    ]
+  );
+
+  useEffect(() => {
+    if (!provider || !balance) return;
+    computeRealMaxBalance(balance.value).then((balanceMinusFee) =>
+      setMaxBalance(balanceMinusFee)
+    );
+  }, [provider, balance, computeRealMaxBalance]);
+
+  return maxBalance;
+}

--- a/features/max-button/index.ts
+++ b/features/max-button/index.ts
@@ -1,0 +1,1 @@
+export * from "./MaxButton";


### PR DESCRIPTION
This PR introduces atomic design. Since satellite will grow in complexity, the usual pages/components structure is too simplistic. 

To keep development time and code quality reasonable, we now break/refactor component groups into features with their substructure.

eg:
<img width="367" alt="CleanShot 2022-12-06 at 15 36 31@2x" src="https://user-images.githubusercontent.com/7473791/205955647-4346c333-7db3-4041-ac84-e1e5159bb9ee.png">


This PR adds the feature `max-button` that correctly handles the case where the transaction fee should be subtracted from the max native asset amount.