### PR TITLE
fix: fixing bug where checkmark for native/erc20 goes away with start…

### DIFF
--- a/store/stores/swap-store/computed.ts
+++ b/store/stores/swap-store/computed.ts
@@ -2,7 +2,7 @@ import { AssetConfig, ChainInfo } from "@axelar-network/axelarjs-sdk";
 import memoize from "proxy-memoize";
 import { ENVIRONMENT } from "../../../config/constants";
 import { getWagmiChains } from "../../../config/web3";
-import { NativeAssetConfig } from "../../../config/web3/evm/native-assets";
+import { NativeAssetConfig, nativeAssets } from "../../../config/web3/evm/native-assets";
 
 export const getSrcChainId = memoize((state: { srcChain: ChainInfo }) => {
   if (!state.srcChain) return undefined;
@@ -115,13 +115,14 @@ export const getUnwrappedAssetName = memoize(
     if (!isWrappedAsset) return null;
 
     // return asset symbol if wrapped asset
-    const nativeAsset = state.destChain.assets?.find(
-      (asset) =>
-        (asset as any).is_native_asset &&
-        asset.native_chain === state.destChain?.chainName?.toLowerCase()
-    );
+    const nativeAsset = nativeAssets.find(na => na.native_chain === state.destChain?.chainName.toLowerCase());
+    // const nativeAsset = state.destChain.assets?.find(
+    //   (asset) =>
+    //     (asset as any).is_native_asset &&
+    //     asset.native_chain === state.destChain?.chainName?.toLowerCase()
+    // );
 
-    return nativeAsset?.assetSymbol;
+    return nativeAsset?.chain_aliases[state.destChain?.chainName.toLowerCase()]?.assetSymbol;
   }
 );
 


### PR DESCRIPTION
To reproduce bug:
1. start a transfer with a native asset combination (e.g. sending WFTM from Avalanche to Fantom). 
2. Generate deposit address
3. Hit start over
=> You will see that the option to toggle to receive native disappears. 

The reason is in this line: https://github.com/axelarnetwork/axelar-satellite/blob/develop/components/swap/parts/UnwrapToNativeChainCheckbox.tsx#L10

When you hit start over, there is a temporal issue where the native asset is not yet in the list of assets (because those native assets are injected on startup of Satellite) for the dest chain, as computed here, so the computed function returns null here: https://github.com/axelarnetwork/axelar-satellite/blob/develop/store/stores/swap-store/computed.ts#L118

The temporary "fix" is to grab the native asset from the hard-coded config instead of from the list of assets