### PR TITLE
feat: add fraxtal and blast chain config

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "socket.io-client": "^4.7.2",
     "spinners-react": "^1.0.7",
     "usehooks-ts": "^2.9.1",
-    "viem": "~1.16.0",
+    "viem": "~1.16.5",
     "wagmi": "1.4.1",
     "wait": "^0.4.2",
     "zustand": "^4.4.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,7 @@ dependencies:
     specifier: ^2.9.1
     version: 2.9.1(react-dom@18.2.0)(react@18.2.0)
   viem:
-    specifier: ~1.16.0
+    specifier: ~1.16.5
     version: 1.16.5(typescript@5.1.6)
   wagmi:
     specifier: 1.4.1
@@ -854,7 +854,7 @@ packages:
       '@cosmjs/encoding': 0.30.1
       '@cosmjs/math': 0.30.1
       '@cosmjs/utils': 0.30.1
-      '@noble/hashes': 1.3.1
+      '@noble/hashes': 1.3.2
       bn.js: 5.2.1
       elliptic: 6.5.4
       libsodium-wrappers: 0.7.11
@@ -2162,10 +2162,6 @@ packages:
     dependencies:
       '@noble/hashes': 1.3.2
     dev: false
-
-  /@noble/hashes@1.3.1:
-    resolution: {integrity: sha512-EbqwksQwz9xDRGfDST86whPBgM65E0OH/pCgqW0GBVzO22bNE+NuIbeTb714+IfSjU3aRk47EUvXIb5bTsenKA==}
-    engines: {node: '>= 16'}
 
   /@noble/hashes@1.3.2:
     resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}

--- a/src/config/web3/evm/mainnet/blast.ts
+++ b/src/config/web3/evm/mainnet/blast.ts
@@ -1,0 +1,28 @@
+import { defineChain } from "viem";
+
+import { ChainExtension } from "../interface";
+
+export const blast: ChainExtension = defineChain({
+  id: 81457,
+  name: "Blast",
+  network: "blast",
+  nativeCurrency: {
+    decimals: 18,
+    name: "Ether",
+    symbol: "ETH",
+  },
+  rpcUrls: {
+    default: { http: ["https://rpc.blast.io"] },
+    public: { http: ["https://rpc.blast.io"] },
+  },
+  blockExplorers: {
+    default: { name: "Blastscan", url: "https://blastscan.io" },
+  },
+  contracts: {
+    multicall3: {
+      address: "0xcA11bde05977b3631167028862bE2a173976CA11",
+      blockCreated: 212929,
+    },
+  },
+  networkNameOverride: "blast",
+});

--- a/src/config/web3/evm/mainnet/fraxtal.ts
+++ b/src/config/web3/evm/mainnet/fraxtal.ts
@@ -1,0 +1,31 @@
+import { defineChain } from "viem";
+
+import { ChainExtension } from "../interface";
+
+export const fraxtal: ChainExtension = defineChain({
+  id: 252,
+  network: "fraxtal",
+  name: "Fraxtal",
+  nativeCurrency: { name: "Frax Ether", symbol: "frxETH", decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ["https://rpc.frax.com"],
+    },
+    public: {
+      http: ["https://rpc.frax.com"],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: "fraxscan",
+      url: "https://fraxscan.com",
+      apiUrl: "https://api.fraxscan.com/api",
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: "0xca11bde05977b3631167028862be2a173976ca11",
+    },
+  },
+  networkNameOverride: "fraxtal",
+});

--- a/src/config/web3/evm/mainnet/index.ts
+++ b/src/config/web3/evm/mainnet/index.ts
@@ -3,6 +3,7 @@ import { arbitrum } from "./arbitrum";
 import { avalanche } from "./avalanche";
 import { base } from "./base";
 import { binance } from "./binance";
+import { blast } from "./blast";
 import { celo } from "./celo";
 import { ethereum } from "./ethereum";
 import { fantom } from "./fantom";
@@ -22,6 +23,7 @@ export const mainnetChains: ChainExtension[] = [
   avalanche,
   base,
   binance,
+  blast,
   celo,
   ethereum,
   filecoin,

--- a/src/config/web3/evm/mainnet/index.ts
+++ b/src/config/web3/evm/mainnet/index.ts
@@ -7,6 +7,7 @@ import { celo } from "./celo";
 import { ethereum } from "./ethereum";
 import { fantom } from "./fantom";
 import { filecoin } from "./filecoin";
+import { fraxtal } from "./fraxtal";
 import { kava } from "./kava";
 import { linea } from "./linea";
 import { mantle } from "./mantle";
@@ -24,6 +25,7 @@ export const mainnetChains: ChainExtension[] = [
   celo,
   ethereum,
   filecoin,
+  fraxtal,
   kava,
   linea,
   moonbeam,

--- a/src/config/web3/evm/testnet/arbitrum.ts
+++ b/src/config/web3/evm/testnet/arbitrum.ts
@@ -1,4 +1,4 @@
-import { arbitrumGoerli as arbitrumConfig } from "viem/chains";
+import { arbitrumSepolia as arbitrumConfig } from "viem/chains";
 
 import { ChainExtension } from "../interface";
 

--- a/src/config/web3/evm/testnet/base.ts
+++ b/src/config/web3/evm/testnet/base.ts
@@ -1,8 +1,8 @@
-import { baseGoerli } from "viem/chains";
+import { baseSepolia } from "viem/chains";
 
 import { ChainExtension } from "../interface";
 
 export const base: ChainExtension = {
-  ...baseGoerli,
+  ...baseSepolia,
   networkNameOverride: "base",
 };

--- a/src/config/web3/evm/testnet/blast.ts
+++ b/src/config/web3/evm/testnet/blast.ts
@@ -1,0 +1,29 @@
+import { defineChain } from "viem";
+
+import { ChainExtension } from "../interface";
+
+export const blast: ChainExtension = defineChain({
+  id: 168_587_773,
+  name: "Blast Sepolia",
+  network: "blast",
+  nativeCurrency: {
+    decimals: 18,
+    name: "Ether",
+    symbol: "ETH",
+  },
+  rpcUrls: {
+    default: { http: ["https://sepolia.blast.io"] },
+    public: { http: ["https://sepoliablast.io"] },
+  },
+  blockExplorers: {
+    default: { name: "Blastscan", url: "https://testnet.blastscan.io" },
+  },
+  contracts: {
+    multicall3: {
+      address: "0xca11bde05977b3631167028862be2a173976ca11",
+      blockCreated: 756690,
+    },
+  },
+  testnet: true,
+  networkNameOverride: "blast",
+});

--- a/src/config/web3/evm/testnet/ethereum.ts
+++ b/src/config/web3/evm/testnet/ethereum.ts
@@ -1,4 +1,4 @@
-import { goerli as ethereumConfig } from "viem/chains";
+import { sepolia as ethereumConfig } from "viem/chains";
 
 import { ChainExtension } from "../interface";
 

--- a/src/config/web3/evm/testnet/fraxtal.ts
+++ b/src/config/web3/evm/testnet/fraxtal.ts
@@ -27,5 +27,6 @@ export const fraxtal: ChainExtension = defineChain({
       address: "0xca11bde05977b3631167028862be2a173976ca11",
     },
   },
+  testnet: true,
   networkNameOverride: "fraxtal",
 });

--- a/src/config/web3/evm/testnet/fraxtal.ts
+++ b/src/config/web3/evm/testnet/fraxtal.ts
@@ -1,0 +1,31 @@
+import { defineChain } from "viem";
+
+import { ChainExtension } from "../interface";
+
+export const fraxtal: ChainExtension = defineChain({
+  id: 2522,
+  network: "fraxtal",
+  name: "Fraxtal Testnet",
+  nativeCurrency: { name: "Frax Ether", symbol: "frxETH", decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ["https://rpc.testnet.frax.com"],
+    },
+    public: {
+      http: ["https://rpc.testnet.frax.com"],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: "fraxscan testnet",
+      url: "https://holesky.fraxscan.com",
+      apiUrl: "https://api-holesky.fraxscan.com/api",
+    },
+  },
+  contracts: {
+    multicall3: {
+      address: "0xca11bde05977b3631167028862be2a173976ca11",
+    },
+  },
+  networkNameOverride: "fraxtal",
+});

--- a/src/config/web3/evm/testnet/index.ts
+++ b/src/config/web3/evm/testnet/index.ts
@@ -8,6 +8,7 @@ import { celo } from "./celo";
 import { ethereum } from "./ethereum";
 import { fantom } from "./fantom";
 import { filecoin } from "./filecoin";
+import { fraxtal } from "./fraxtal";
 import { kava } from "./kava";
 import { linea } from "./linea";
 import { mantle } from "./mantle";
@@ -25,6 +26,7 @@ export const testnetChains: ChainExtension[] = [
   moonbeam,
   fantom,
   filecoin,
+  fraxtal,
   polygon,
   polygonZkEvm,
   binance,

--- a/src/config/web3/evm/testnet/index.ts
+++ b/src/config/web3/evm/testnet/index.ts
@@ -4,6 +4,7 @@ import { aurora } from "./aurora";
 import { avalanche } from "./avalanche";
 import { base } from "./base";
 import { binance } from "./binance";
+import { blast } from "./blast";
 import { celo } from "./celo";
 import { ethereum } from "./ethereum";
 import { fantom } from "./fantom";
@@ -22,6 +23,7 @@ export const testnetChains: ChainExtension[] = [
   aurora,
   avalanche,
   base,
+  blast,
   ethereum,
   moonbeam,
   fantom,

--- a/src/config/web3/evm/testnet/optimism.ts
+++ b/src/config/web3/evm/testnet/optimism.ts
@@ -1,4 +1,4 @@
-import { optimismGoerli as optimismConfig } from "viem/chains";
+import { optimismSepolia as optimismConfig } from "viem/chains";
 
 import { ChainExtension } from "../interface";
 

--- a/src/features/swap-states/states/06.SrcChainTxPropagation.tsx
+++ b/src/features/swap-states/states/06.SrcChainTxPropagation.tsx
@@ -83,7 +83,7 @@ export const SrcChainTxPropagation = () => {
 
     let name = "";
     if (srcChain.chainName.toLowerCase()?.includes("base")) {
-      name = "Goerli L1";
+      name = "Sepolia L1";
     } else {
       name = srcChain.chainName;
     }

--- a/src/store/stores/swap-store/computed.ts
+++ b/src/store/stores/swap-store/computed.ts
@@ -289,6 +289,7 @@ const getWagmiChainOverride = (wagmiNetwork: string) => {
     ropsten: "ethereum",
     homestead: "ethereum",
     goerli: "ethereum",
+    sepolia: "ethereum",
   };
   return map[wagmiNetwork] || wagmiNetwork;
 };


### PR DESCRIPTION
# Description

[AXE-3404](https://axelarnetwork.atlassian.net/browse/AXE-3404)

This PR added fraxtal and blast chain config. Also, updates the existing imported testnet chains from `viem/chains` from goerli based to sepolia based

look like it works now

![image](https://github.com/axelarnetwork/axelar-satellite/assets/78221556/c27b950e-3fd7-4fdb-a484-a790c0aab898)

[AXE-3404]: https://axelarnetwork.atlassian.net/browse/AXE-3404?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ