### PR TITLE
Update Agoric explorer URL

### DIFF
--- a/src/config/web3/cosmos/mainnet/agoric.ts
+++ b/src/config/web3/cosmos/mainnet/agoric.ts
@@ -38,5 +38,5 @@ export const agoric: CosmosChain = {
   chainIdentifier: "agoric",
   chainToAxelarChannelId: "channel-9",
   features: ["stargate", "ibc-transfer", "no-legacy-stdTx", "ibc-go"],
-  explorer: "https://bigdipper.live/agoric/accounts/",
+  explorer: "https://agoric.explorers.guru/account/",
 };


### PR DESCRIPTION
Updated Agoric explorer URL to 'https://agoric.explorers.guru/account/' following Big Dipper's drop of support, referenced Agoric's tweet: https://twitter.com/bigdipperlive/status/1766162059690119486.