### PR TITLE
chore: fix rpc endpoint for evmos

### DIFF
--- a/src/config/web3/cosmos/mainnet/evmos.ts
+++ b/src/config/web3/cosmos/mainnet/evmos.ts
@@ -5,7 +5,7 @@ import { Bech32Address } from "@keplr-wallet/cosmos";
 import { CosmosChain } from "../interface";
 
 export const evmos: CosmosChain = {
-  rpc: `https://rpc-evmos.validavia.me`, // `${COSMOS_PROXY_RPC_MAINNET}/chain/evmos`,
+  rpc: `https://evmos-rpc.polkachu.com`, // `${COSMOS_PROXY_RPC_MAINNET}/chain/evmos`,
   rest: "https://lcd-evmos.imperator.co", //"https://mainnet-lcd-router.axelar-dev.workers.dev", TODO - get LCD router to work so that we can retry
   chainId: "evmos_9001-2",
   chainName: "Evmos",


### PR DESCRIPTION
# Description

Closed https://github.com/axelarnetwork/axelar-satellite/issues/482

The current rpc endpoint for evmos doesn't work. This PR swapped it out for a new one. Tested by executing the status endpoint like below:

```
curl -X POST https://evmos-rpc.polkachu.com/status -H "Content-Type: application/json" | jq .
```

output:
```
{"jsonrpc":"2.0","id":-1,"result":{"node_info":{"protocol_version":{"p2p":"8","block":"11","app":"0"},"id":"4c782ab277fca003d3b5e1c53d2be2b592259385","listen_addr":"65.108.39.140:13456","network":"evmos_9001-2","version":"0.37.9","channels":"40202122233038606100","moniker":"hello-evmos-relayer","other":{"tx_index":"on","rpc_address":"tcp://0.0.0.0:13457"}},"sync_info":{"latest_block_hash":"606881E7BF31E5F5400B94B022B3E0A1EFE9B37E4D6F86E92B23FC48300B1BCD","latest_app_hash":"93C39DF092821AE32D07AC131F44C2000073174BA3ABAEA39A909A3CF30C1CBA","latest_block_height":"23279250","latest_block_time":"2024-09-05T05:31:32.302003644Z","earliest_block_hash":"886E6CA9BEA6371919A5C8E3474B6D742D47B4032F60C1375678BBBB8C3E49BD","earliest_app_hash":"4B54CD20264BBEB8831967B99A6745CEBD31158692125B50F9375B69913EBF0E","earliest_block_height":"17744031","earliest_block_time":"2023-12-15T16:03:54.111955399Z","catching_up":false},"validator_info":{"address":"8022C616BF5DEEE5BEBDBA7E4FFA6BFCAC6DA4EE","pub_key":{"type":"tendermint/PubKeyEd25519","value":"+GUncqj4noawmRDiAkLVZqVDplBbKi7lSCt6stqHICU="},"voting_power":"0"}}}
```